### PR TITLE
Point templates skill at renamed templates-org vals

### DIFF
--- a/.changeset/templates-org-slugs.md
+++ b/.changeset/templates-org-slugs.md
@@ -1,0 +1,5 @@
+---
+"@valtown/skills": patch
+---
+
+Point templates skill at renamed templates-org vals (`react-hono-starter`, `basic-html-starter`, `telegram-bot-starter`) so `remix_val` targets resolve.

--- a/plugin/skills/templates/SKILL.md
+++ b/plugin/skills/templates/SKILL.md
@@ -14,13 +14,13 @@ Map the user's intent to the closest starter:
 
 | Project shape | Template |
 | --- | --- |
-| Interactive web app (dashboard, SaaS, CRUD, form, anything with client-side state) | `std/reactHonoStarter` |
-| Static page (landing page, link-in-bio, simple docs) | `std/basic-html-starter` |
+| Interactive web app (dashboard, SaaS, CRUD, form, anything with client-side state) | `templates/react-hono-starter` |
+| Static page (landing page, link-in-bio, simple docs) | `templates/basic-html-starter` |
 | AI agent built with OpenAI Agents SDK | `templates/openai-agents` |
 | AI agent, model-agnostic (Vercel AI SDK) | `templates/vercel-ai-agent-demo` |
 | Webhook + AI + dashboard (lead qualification, enrichment) | `templates/leads` |
 | Webhook + enrichment + Slack | `templates/new-user-enrichment` |
-| Telegram bot | `templates/telegramBotStarter` |
+| Telegram bot | `templates/telegram-bot-starter` |
 
 Full list of official starters: https://www.val.town/orgs/templates
 


### PR DESCRIPTION
The `reactHonoStarter`, `basic-html-starter`, and `telegramBotStarter` starters were moved into the `templates` org under kebab-case names. The `templates` skill catalog still pointed at the old slugs, so `remix_val` targets no longer resolve to the canonical vals.

Verified against the live `templates` org (the old vals are now unlisted with `description: "Renamed to …"`):

| Old slug | New slug |
| --- | --- |
| `std/reactHonoStarter` | `templates/react-hono-starter` |
| `std/basic-html-starter` | `templates/basic-html-starter` |
| `templates/telegramBotStarter` | `templates/telegram-bot-starter` |

The `react-ui` skill's `std/reactHonoStarter` reference was already fixed on `main`, so this only touches `plugin/skills/templates/SKILL.md`. `npm run build` (the schema/frontmatter validation gate) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/plugins/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->