### PR TITLE
Fix npm publish: repository.url -> val-town/plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/val-town/claude.git"
+    "url": "git+https://github.com/val-town/plugins.git"
   },
   "homepage": "https://val.town",
   "publishConfig": {


### PR DESCRIPTION
## Why

Merging the `0.1.2` Version Packages PR triggered the publish, which **failed**:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
package.json: "repository.url" is "git+https://github.com/val-town/claude.git",
expected to match "https://github.com/val-town/plugins" from provenance
```

The repo was renamed `val-town/claude` → `val-town/plugins`, but `package.json`'s `repository.url` still pointed at the old name. npm OIDC trusted-publishing requires `repository.url` to match the repo the provenance was generated in. (`0.1.0`/`0.1.1` predate the rename, so they published fine.)

## Fix

One line: `repository.url` → `git+https://github.com/val-town/plugins.git`.

`0.1.2` is bumped on `main` but **not yet on npm** (`latest` is still `0.1.1`). Once this lands on `main`, `release.yml` re-runs, sees `0.1.2` is unpublished, and publishes it — now with matching provenance.

> Note: `plugin/.claude-plugin/plugin.json` has the same stale `val-town/claude` URL. It doesn't gate npm publishing, and that file is owned by #12, so I left it alone — worth fixing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)