### PR TITLE
Add Cursor plugin support

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "valtown",
+  "owner": {
+    "name": "Val Town",
+    "url": "https://val.town"
+  },
+  "metadata": {
+    "description": "Val Town MCP server + platform skills for building and deploying vals.",
+    "version": "0.1.2"
+  },
+  "plugins": [
+    {
+      "name": "vals",
+      "source": "./plugin",
+      "description": "Val Town MCP server + platform skills for building and deploying vals."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ codex /plugins
 Codex reads the native marketplace at `.agents/plugins/marketplace.json` (and
 falls back to the Claude `.claude-plugin/marketplace.json` for compatibility).
 
+### Cursor
+
+Install from the [Cursor Marketplace](https://cursor.com/marketplace), or add this
+repo as a marketplace source. Cursor reads `.cursor-plugin/marketplace.json` and
+the per-plugin `plugin/.cursor-plugin/plugin.json`.
+
 ---
 
 Either way, this makes the platform skills available to the agent and registers

--- a/plugin/.cursor-plugin/plugin.json
+++ b/plugin/.cursor-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "vals",
+  "displayName": "Val Town",
+  "version": "0.1.2",
+  "description": "Build and deploy on Val Town. Bundles the Val Town MCP server and platform skills (HTTP vals, cron/intervals, SQLite, email, OAuth, React UI, third-party integrations, templates).",
+  "author": {
+    "name": "Val Town",
+    "url": "https://val.town"
+  },
+  "license": "MIT",
+  "keywords": ["val-town", "deno", "serverless", "typescript", "cursor", "mcp"],
+  "logo": "assets/icon.svg"
+}

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "valtown": {
+      "url": "https://api.val.town/v3/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## What

Makes `val-town/plugins` installable as a **Cursor** plugin, alongside Claude Code and Codex.

Cursor 2.5+ ships an open plugin marketplace using the same primitives (skills, rules, MCP servers) and nearly the same on-disk structure as Claude Code / Codex — so this is a small, mostly-mechanical addition that reuses the existing skills and icon.

## Changes

- **`.cursor-plugin/marketplace.json`** — Cursor marketplace manifest (string `source: ./plugin`, mirrors our Claude marketplace).
- **`plugin/.cursor-plugin/plugin.json`** — Cursor plugin manifest (reuses `assets/icon.svg` as `logo`). Cursor auto-discovers `skills/` and `mcp.json`, so no pointer/`interface` fields are needed.
- **`plugin/mcp.json`** — Cursor MCP config. Note: Cursor's spec uses `mcp.json` (no leading dot), distinct from Claude/Codex `.mcp.json`. Remote streamable-HTTP via `url`.
- **README** — add a Cursor install section.

## Listing

Cursor's marketplace requires submitting the (open-source) repo for manual review at <https://cursor.com/marketplace/publish>. This PR makes the repo submission-ready; the actual submit is a one-time web step.

## Notes

- Shares the same `SKILL.md` files as the other plugins (Cursor reads the same skill format).
- `npm test` passes (skills build unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/plugins/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->