### PR TITLE
Sync all plugin manifest versions on release (not just Claude)

### DIFF
--- a/.changeset/sync-all-plugin-manifests.md
+++ b/.changeset/sync-all-plugin-manifests.md
@@ -1,0 +1,5 @@
+---
+"@valtown/skills": patch
+---
+
+Version sync now updates every plugin manifest (Claude, Codex, and Cursor plugin.json plus the Cursor marketplace.json `metadata.version`), not just the Claude manifest — preventing the Codex/Cursor manifests from advertising a stale version on release.

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,9 +1,10 @@
-// Syncs the Claude plugin manifest version to the npm package version.
+// Syncs every plugin manifest version to the npm package version.
 //
-// Changesets only bumps package.json. This keeps
-// plugin/.claude-plugin/plugin.json in lockstep so the published plugin and
-// the npm package never drift. Run as part of the `version` script, so the
-// bump lands in the "Version Packages" PR alongside the changelog.
+// Changesets only bumps package.json. This keeps the Claude, Codex, and Cursor
+// plugin manifests (and the Cursor marketplace manifest) in lockstep so the
+// published plugins and the npm package never drift. Run as part of the
+// `version` script, so the bump lands in the "Version Packages" PR alongside
+// the changelog.
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -11,7 +12,15 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const PKG_FILE = join(ROOT, "package.json");
-const PLUGIN_FILE = join(ROOT, "plugin", ".claude-plugin", "plugin.json");
+
+// Manifests that carry a version which must track the npm package version.
+// `key` is the dotted path to the version field within each JSON file.
+const TARGETS = [
+  { file: join(ROOT, "plugin", ".claude-plugin", "plugin.json"), key: "version" },
+  { file: join(ROOT, "plugin", ".codex-plugin", "plugin.json"), key: "version" },
+  { file: join(ROOT, "plugin", ".cursor-plugin", "plugin.json"), key: "version" },
+  { file: join(ROOT, ".cursor-plugin", "marketplace.json"), key: "metadata.version" },
+];
 
 const { version } = JSON.parse(readFileSync(PKG_FILE, "utf8"));
 if (typeof version !== "string" || version.length === 0) {
@@ -19,18 +28,39 @@ if (typeof version !== "string" || version.length === 0) {
   process.exit(1);
 }
 
-const raw = readFileSync(PLUGIN_FILE, "utf8");
-const plugin = JSON.parse(raw);
+const getAt = (obj, key) => key.split(".").reduce((o, k) => (o == null ? o : o[k]), obj);
+const setAt = (obj, key, value) => {
+  const path = key.split(".");
+  const last = path.pop();
+  const parent = path.reduce((o, k) => (o[k] ??= {}), obj);
+  parent[last] = value;
+};
 
-if (plugin.version === version) {
-  console.log(`✓ Plugin version already in sync (${version})`);
-  process.exit(0);
+let failed = false;
+for (const { file, key } of TARGETS) {
+  const rel = file.slice(ROOT.length + 1);
+  let raw;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch {
+    console.error(`✗ Missing manifest: ${rel}`);
+    failed = true;
+    continue;
+  }
+
+  const manifest = JSON.parse(raw);
+  const previous = getAt(manifest, key);
+
+  if (previous === version) {
+    console.log(`✓ ${rel} already in sync (${version})`);
+    continue;
+  }
+
+  setAt(manifest, key, version);
+  // Preserve trailing newline if the original had one.
+  const trailing = raw.endsWith("\n") ? "\n" : "";
+  writeFileSync(file, JSON.stringify(manifest, null, 2) + trailing);
+  console.log(`✓ Synced ${rel} ${previous} -> ${version}`);
 }
 
-const previous = plugin.version;
-plugin.version = version;
-
-// Preserve trailing newline if the original had one.
-const trailing = raw.endsWith("\n") ? "\n" : "";
-writeFileSync(PLUGIN_FILE, JSON.stringify(plugin, null, 2) + trailing);
-console.log(`✓ Synced plugin version ${previous} -> ${version}`);
+if (failed) process.exit(1);


### PR DESCRIPTION
## Problem

`scripts/sync-plugin-version.mjs` only synced `plugin/.claude-plugin/plugin.json`. After the Codex (#18) and Cursor (#21) plugin manifests were added, the script left them — and `.cursor-plugin/marketplace.json` — behind.

On release, `changeset version` bumps `package.json` and the Claude manifest, but the Codex/Cursor manifests would keep advertising the **old** version to their marketplaces. Version drift.

## Fix

Refactor the script to iterate over all version-bearing manifests:

- `plugin/.claude-plugin/plugin.json` → `version`
- `plugin/.codex-plugin/plugin.json` → `version`
- `plugin/.cursor-plugin/plugin.json` → `version`
- `.cursor-plugin/marketplace.json` → `metadata.version` (nested — handled via dotted-key get/set)

Idempotent (skips already-in-sync files), preserves trailing newlines, and fails loudly if a listed manifest is missing.

## Test

Temporarily bumped `package.json` to `0.1.3` and ran the script:

```
✓ Synced plugin/.claude-plugin/plugin.json 0.1.2 -> 0.1.3
✓ Synced plugin/.codex-plugin/plugin.json 0.1.2 -> 0.1.3
✓ Synced plugin/.cursor-plugin/plugin.json 0.1.2 -> 0.1.3
✓ Synced .cursor-plugin/marketplace.json 0.1.2 -> 0.1.3
```

Re-run reported all four already in sync (idempotent). Reverted the test bump. `npm test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/plugins/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->