### PR TITLE
Add oauth.authServerMetadataUrl hint to bundled .mcp.json

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "valtown": {
       "type": "http",
-      "url": "https://api.val.town/v3/mcp"
+      "url": "https://api.val.town/v3/mcp",
+      "oauth": {
+        "authServerMetadataUrl": "https://api.val.town/.well-known/oauth-authorization-server"
+      }
     }
   }
 }

--- a/plugin/mcp.json
+++ b/plugin/mcp.json
@@ -1,7 +1,10 @@
 {
   "mcpServers": {
     "valtown": {
-      "url": "https://api.val.town/v3/mcp"
+      "url": "https://api.val.town/v3/mcp",
+      "oauth": {
+        "authServerMetadataUrl": "https://api.val.town/.well-known/oauth-authorization-server"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds an `oauth.authServerMetadataUrl` hint pointing at `https://api.val.town/.well-known/oauth-authorization-server` to both `plugin/.mcp.json` and `plugin/mcp.json`.

## Why
While debugging #41 (installing the plugin never triggers auth, tools silently unavailable), we found the plugin manifest schema supports an optional `oauth` block on an MCP server entry, which our config wasn't using.

This alone does **not** fix #41 — the network trace in that issue shows the plugin-install flow never attempts a connection to the MCP server at all, so no client-side hint here changes that. It's also likely to be silently stripped during marketplace sync per anthropics/claude-ai-mcp#359. Adding it anyway since it's low-risk/correct, and puts us in a better position once #359 and the underlying install-flow gap are fixed upstream.

## Test plan
- [x] Verified Val Town's authorization server metadata resolves correctly at that URL (confirmed via curl during #41 investigation)
- [ ] Re-verify plugin install behavior once upstream fixes land