### PR TITLE
Teach Versioned Immutable Asset Caching in the UI Skills

### DIFF
--- a/.changeset/versioned-assets-skills.md
+++ b/.changeset/versioned-assets-skills.md
@@ -2,4 +2,4 @@
 "@valtown/skills": patch
 ---
 
-Teach the versioned-immutable asset-caching pattern (`versionedAssets` from `std/utils`) as the default way to serve client modules, in the `client-side-js`, `http-endpoints`, and `react-ui` skills. The HTML shell stamps `/v<version>/...` asset URLs, `serve()` answers them with `Cache-Control: immutable` (stale versions 302 to current), and publishing the val bumps the version so invalidation is instant. Measured: repeat visits 665ms → 157ms with zero asset requests.
+Teach the immutable asset-caching pattern (`serveImmutableFile` / `immutableFileUrl` from `std/utils`) as the default way to serve client modules, in the `client-side-js`, `http-endpoints`, and `react-ui` skills. The never-cached HTML shell stamps `/__immutable/<version>/...` asset URLs, `serveImmutableFile` answers them with `Cache-Control: immutable` (stale versions 302 to current), and publishing the val bumps the version so invalidation is instant. Measured: repeat visits 665ms → 157ms with zero asset requests.

--- a/.changeset/versioned-assets-skills.md
+++ b/.changeset/versioned-assets-skills.md
@@ -1,0 +1,5 @@
+---
+"@valtown/skills": patch
+---
+
+Teach the versioned-immutable asset-caching pattern (`versionedAssets` from `std/utils`) as the default way to serve client modules, in the `client-side-js`, `http-endpoints`, and `react-ui` skills. The HTML shell stamps `/v<version>/...` asset URLs, `serve()` answers them with `Cache-Control: immutable` (stale versions 302 to current), and publishing the val bumps the version so invalidation is instant. Measured: repeat visits 665ms → 157ms with zero asset requests.

--- a/.changeset/versioned-assets-skills.md
+++ b/.changeset/versioned-assets-skills.md
@@ -2,4 +2,4 @@
 "@valtown/skills": patch
 ---
 
-Teach the immutable asset-caching pattern (`serveImmutableFile` / `immutableFileUrl` from `std/utils`) as the default way to serve client modules, in the `client-side-js`, `http-endpoints`, and `react-ui` skills. The never-cached HTML shell stamps `/__immutable/<version>/...` asset URLs, `serveImmutableFile` answers them with `Cache-Control: immutable` (stale versions 302 to current), and publishing the val bumps the version so invalidation is instant. Measured: repeat visits 665ms → 157ms with zero asset requests.
+Teach the immutable asset-caching pattern (`serveImmutableFile` / `immutableFileUrl` from `std/utils`) in the `client-side-js`, `http-endpoints`, and `react-ui` skills: the never-cached HTML shell stamps `/__immutable/<version>/...` URLs, served with `Cache-Control: immutable`; publishing bumps the version, invalidating automatically (old-version URLs 404). Measured: repeat visits 665ms → 157ms with zero asset requests.

--- a/plugin/skills/client-side-js/SKILL.md
+++ b/plugin/skills/client-side-js/SKILL.md
@@ -44,28 +44,29 @@ and paths don't resolve, pass `import.meta.url` as the second argument.
 ## Default: versioned, immutably cached modules
 
 Served this way, every page load refetches and re-transpiles every module. The
-default pattern adds version-stamped URLs with immutable caching on top —
+default pattern adds version-addressed URLs with immutable caching on top —
 measured on a 3-module React app, repeat visits went **665ms → 157ms with zero
 asset requests**:
 
 ```ts
-import { versionedAssets } from "https://esm.town/v/std/utils/index.ts";
-
-const assets = versionedAssets();
+import { serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
 
 // current version → served with Cache-Control: immutable; stale version → 302
-app.get("/v*", (c) => assets.serve(c.req.raw));
+app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
 ```
 
-In the HTML shell, stamp the entry module with `assets.url("/frontend/index.tsx")`,
-which returns `/v42/frontend/index.tsx` (42 = the val's current version). Relative
-imports resolve under the same `/v42/` prefix, so the whole client module graph is
-version-addressed automatically — only the entry needs stamping.
+In the HTML shell, stamp the entry module with `immutableFileUrl("/frontend/index.tsx")`,
+which returns `/__immutable/42/frontend/index.tsx` (42 = the val's current version).
+Relative imports resolve under the same `/__immutable/42/` prefix, so the whole client
+module graph is version-addressed automatically — only the entry needs stamping. This
+works for root-level files too: `immutableFileUrl("/logo.png")` → `/__immutable/42/logo.png`.
 
 Invalidation is automatic: publishing the val bumps its version, the never-cached
 shell stamps the new prefix, and browsers refetch each asset exactly once; requests
-for old versions 302 to the current one. Paths without a `/v<version>/` prefix fall
-through to plain uncached `serveFile`, so unstamped URLs keep working.
+for old versions 302 to the current one. Keep a plain `serveFile` route as the
+fallback so unstamped URLs keep working — or point that route at `serveImmutableFile`
+too, which 302s bare paths into `/__immutable/<version>/` (zero config, at the cost
+of one redirect per page view).
 
 ### Alternative: serve directly from esm.town
 

--- a/plugin/skills/client-side-js/SKILL.md
+++ b/plugin/skills/client-side-js/SKILL.md
@@ -41,6 +41,32 @@ app.get("/client/**/*", (c) => serveFile(c.req.path));
 `serveFile` defaults to the current val. If you call it from a non-entrypoint file
 and paths don't resolve, pass `import.meta.url` as the second argument.
 
+## Default: versioned, immutably cached modules
+
+Served this way, every page load refetches and re-transpiles every module. The
+default pattern adds version-stamped URLs with immutable caching on top —
+measured on a 3-module React app, repeat visits went **665ms → 157ms with zero
+asset requests**:
+
+```ts
+import { versionedAssets } from "https://esm.town/v/std/utils/index.ts";
+
+const assets = versionedAssets();
+
+// current version → served with Cache-Control: immutable; stale version → 302
+app.get("/v*", (c) => assets.serve(c.req.raw));
+```
+
+In the HTML shell, stamp the entry module with `assets.url("/frontend/index.tsx")`,
+which returns `/v42/frontend/index.tsx` (42 = the val's current version). Relative
+imports resolve under the same `/v42/` prefix, so the whole client module graph is
+version-addressed automatically — only the entry needs stamping.
+
+Invalidation is automatic: publishing the val bumps its version, the never-cached
+shell stamps the new prefix, and browsers refetch each asset exactly once; requests
+for old versions 302 to the current one. Paths without a `/v<version>/` prefix fall
+through to plain uncached `serveFile`, so unstamped URLs keep working.
+
 ### Alternative: serve directly from esm.town
 
 Every val file already has a public esm.town URL that transpiles on demand, so you

--- a/plugin/skills/client-side-js/SKILL.md
+++ b/plugin/skills/client-side-js/SKILL.md
@@ -43,30 +43,26 @@ and paths don't resolve, pass `import.meta.url` as the second argument.
 
 ## Default: versioned, immutably cached modules
 
-Served this way, every page load refetches and re-transpiles every module. The
-default pattern adds version-addressed URLs with immutable caching on top —
-measured on a 3-module React app, repeat visits went **665ms → 157ms with zero
-asset requests**:
+`serveImmutableFile` makes your val's frontend faster by letting browsers cache
+files immutably; publishing bumps the val's version, which invalidates
+automatically. Measured: repeat visits **665ms → 157ms with zero asset requests**.
 
 ```ts
-import { serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
+import { immutableFileUrl, serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
 
-// current version → served with Cache-Control: immutable; stale version → 302
 app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
+app.get("/frontend/**/*", (c) => serveImmutableFile(c.req.path)); // bare paths 302 into versioned space
 ```
 
-In the HTML shell, stamp the entry module with `immutableFileUrl("/frontend/index.tsx")`,
-which returns `/__immutable/42/frontend/index.tsx` (42 = the val's current version).
-Relative imports resolve under the same `/__immutable/42/` prefix, so the whole client
-module graph is version-addressed automatically — only the entry needs stamping. This
-works for root-level files too: `immutableFileUrl("/logo.png")` → `/__immutable/42/logo.png`.
+In the never-cached HTML shell, stamp the entry module:
+`immutableFileUrl("/frontend/index.tsx")` → `/__immutable/42/frontend/index.tsx`
+(42 = the val's current version). Relative imports resolve under the same prefix,
+so only the entry needs stamping.
 
-Invalidation is automatic: publishing the val bumps its version, the never-cached
-shell stamps the new prefix, and browsers refetch each asset exactly once; requests
-for old versions 302 to the current one. Keep a plain `serveFile` route as the
-fallback so unstamped URLs keep working — or point that route at `serveImmutableFile`
-too, which 302s bare paths into `/__immutable/<version>/` (zero config, at the cost
-of one redirect per page view).
+- Stamping skips the bare-path redirect; unstamped URLs still work, at one
+  redirect per page view.
+- Old-version URLs 404 after a publish (like Next.js build assets); a reload
+  picks up the new version.
 
 ### Alternative: serve directly from esm.town
 

--- a/plugin/skills/client-side-js/SKILL.md
+++ b/plugin/skills/client-side-js/SKILL.md
@@ -51,18 +51,19 @@ automatically. Measured: repeat visits **665ms → 157ms with zero asset request
 import { immutableFileUrl, serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
 
 app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
-app.get("/frontend/**/*", (c) => serveImmutableFile(c.req.path)); // bare paths 302 into versioned space
 ```
 
 In the never-cached HTML shell, stamp the entry module:
 `immutableFileUrl("/frontend/index.tsx")` → `/__immutable/42/frontend/index.tsx`
 (42 = the val's current version). Relative imports resolve under the same prefix,
-so only the entry needs stamping.
+so only the entry needs stamping — one route and one stamped URL cover the whole
+client graph.
 
-- Stamping skips the bare-path redirect; unstamped URLs still work, at one
-  redirect per page view.
 - Old-version URLs 404 after a publish (like Next.js build assets); a reload
   picks up the new version.
+- Retrofitting an existing val without touching its shell? Also point its old
+  file route at `serveImmutableFile` — bare paths then 302 into versioned space,
+  at one redirect per page view.
 
 ### Alternative: serve directly from esm.town
 

--- a/plugin/skills/http-endpoints/SKILL.md
+++ b/plugin/skills/http-endpoints/SKILL.md
@@ -25,13 +25,19 @@ When using Hono, export `app.fetch` (not `app`):
 
 ```ts
 import { Hono } from "npm:hono";
-import { parseVal, serveFile } from "https://esm.town/v/std/utils/index.ts";
+import { parseVal, serveFile, versionedAssets } from "https://esm.town/v/std/utils/index.ts";
 
 const app = new Hono();
+const assets = versionedAssets();
 
 app.get("/", (c) => c.text("hello"));
 
-// Serve all frontend files, transpiled, with correct content types
+// Serve frontend files versioned + immutably cached. The HTML shell stamps
+// asset URLs with assets.url("/frontend/index.tsx") → "/v42/frontend/index.tsx";
+// publishing bumps the version, so browsers refetch each asset exactly once.
+app.get("/v*", (c) => assets.serve(c.req.raw));
+
+// Unstamped fallback, transpiled, with correct content types (e.g. the favicon)
 app.get("/frontend/**/*", (c) => serveFile(c.req.path));
 
 // View source redirect

--- a/plugin/skills/http-endpoints/SKILL.md
+++ b/plugin/skills/http-endpoints/SKILL.md
@@ -31,10 +31,9 @@ const app = new Hono();
 
 app.get("/", (c) => c.text("hello"));
 
-// Immutable asset caching (see the client-side-js skill): stamped current-version
-// URLs serve immutably, bare paths 302 into versioned space
+// Immutable asset caching (see the client-side-js skill): serves the
+// current-version URLs your HTML shell stamps with immutableFileUrl()
 app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
-app.get("/frontend/**/*", (c) => serveImmutableFile(c.req.path));
 
 // View source redirect
 app.get("/source", (c) => c.redirect(parseVal().links.self.val));

--- a/plugin/skills/http-endpoints/SKILL.md
+++ b/plugin/skills/http-endpoints/SKILL.md
@@ -25,19 +25,16 @@ When using Hono, export `app.fetch` (not `app`):
 
 ```ts
 import { Hono } from "npm:hono";
-import { parseVal, serveFile, serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
+import { parseVal, serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
 
 const app = new Hono();
 
 app.get("/", (c) => c.text("hello"));
 
-// Serve frontend files versioned + immutably cached. The HTML shell stamps asset
-// URLs with immutableFileUrl("/frontend/index.tsx") → "/__immutable/42/frontend/index.tsx";
-// publishing bumps the version, so browsers refetch each asset exactly once.
+// Immutable asset caching (see the client-side-js skill): stamped current-version
+// URLs serve immutably, bare paths 302 into versioned space
 app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
-
-// Unstamped fallback, transpiled, with correct content types
-app.get("/frontend/**/*", (c) => serveFile(c.req.path));
+app.get("/frontend/**/*", (c) => serveImmutableFile(c.req.path));
 
 // View source redirect
 app.get("/source", (c) => c.redirect(parseVal().links.self.val));

--- a/plugin/skills/http-endpoints/SKILL.md
+++ b/plugin/skills/http-endpoints/SKILL.md
@@ -25,19 +25,18 @@ When using Hono, export `app.fetch` (not `app`):
 
 ```ts
 import { Hono } from "npm:hono";
-import { parseVal, serveFile, versionedAssets } from "https://esm.town/v/std/utils/index.ts";
+import { parseVal, serveFile, serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
 
 const app = new Hono();
-const assets = versionedAssets();
 
 app.get("/", (c) => c.text("hello"));
 
-// Serve frontend files versioned + immutably cached. The HTML shell stamps
-// asset URLs with assets.url("/frontend/index.tsx") → "/v42/frontend/index.tsx";
+// Serve frontend files versioned + immutably cached. The HTML shell stamps asset
+// URLs with immutableFileUrl("/frontend/index.tsx") → "/__immutable/42/frontend/index.tsx";
 // publishing bumps the version, so browsers refetch each asset exactly once.
-app.get("/v*", (c) => assets.serve(c.req.raw));
+app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
 
-// Unstamped fallback, transpiled, with correct content types (e.g. the favicon)
+// Unstamped fallback, transpiled, with correct content types
 app.get("/frontend/**/*", (c) => serveFile(c.req.path));
 
 // View source redirect

--- a/plugin/skills/react-ui/SKILL.md
+++ b/plugin/skills/react-ui/SKILL.md
@@ -38,20 +38,21 @@ Avoid inline `<style>` tags, CSS-in-JS objects, or separate `.css` files, unless
 
 ## Serving assets: versioned + immutable
 
-Serve client modules through `versionedAssets` from `std/utils` so repeat visits
+Serve client modules through `serveImmutableFile` from `std/utils` so repeat visits
 load them from the browser cache instead of re-transpiling per request (measured:
-repeat visits 665ms → 157ms, zero asset requests). The shell stamps the entry
-module URL; publishing the val bumps the version, which invalidates instantly:
+repeat visits 665ms → 157ms, zero asset requests). A never-cached `frontend/root.tsx`
+shell component (hono/jsx) stamps the entry module and favicon URLs with
+`immutableFileUrl`; publishing the val bumps the version, which invalidates instantly:
 
 ```tsx
-import { versionedAssets } from "https://esm.town/v/std/utils/index.ts";
-const assets = versionedAssets();
+import { immutableFileUrl, serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
 
-// In the HTML shell:
-<script src={assets.url("/frontend/index.tsx")} type="module" />
+// frontend/root.tsx — in the Root() HTML shell:
+<script src={immutableFileUrl("/frontend/index.tsx")} type="module" />
 
-// In the Hono app — current version → immutable cache, stale → 302 to current:
-app.get("/v*", (c) => assets.serve(c.req.raw));
+// index.ts — the Hono app; current version → immutable cache, stale → 302 to current:
+app.get("/", (c) => c.html(Root()));
+app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
 ```
 
 See the `client-side-js` skill for how modules and their imports are served.

--- a/plugin/skills/react-ui/SKILL.md
+++ b/plugin/skills/react-ui/SKILL.md
@@ -38,24 +38,20 @@ Avoid inline `<style>` tags, CSS-in-JS objects, or separate `.css` files, unless
 
 ## Serving assets: versioned + immutable
 
-Serve client modules through `serveImmutableFile` from `std/utils` so repeat visits
-load them from the browser cache instead of re-transpiling per request (measured:
-repeat visits 665ms → 157ms, zero asset requests). A never-cached `frontend/root.tsx`
-shell component (hono/jsx) stamps the entry module and favicon URLs with
-`immutableFileUrl`; publishing the val bumps the version, which invalidates instantly:
+Serve client modules with `serveImmutableFile` from `std/utils` — browsers cache
+them immutably, and publishing bumps the val's version, which invalidates
+automatically (full pattern: the `client-side-js` skill). A never-cached
+`frontend/root.tsx` shell (hono/jsx) stamps the entry and favicon with
+`immutableFileUrl`:
 
 ```tsx
-import { immutableFileUrl, serveImmutableFile } from "https://esm.town/v/std/utils/index.ts";
-
 // frontend/root.tsx — in the Root() HTML shell:
 <script src={immutableFileUrl("/frontend/index.tsx")} type="module" />
 
-// index.ts — the Hono app; current version → immutable cache, stale → 302 to current:
+// index.ts:
 app.get("/", (c) => c.html(Root()));
 app.get("/__immutable/*", (c) => serveImmutableFile(c.req.path));
 ```
-
-See the `client-side-js` skill for how modules and their imports are served.
 
 ## View source link
 

--- a/plugin/skills/react-ui/SKILL.md
+++ b/plugin/skills/react-ui/SKILL.md
@@ -36,6 +36,26 @@ Then use Tailwind classes directly in JSX:
 
 Avoid inline `<style>` tags, CSS-in-JS objects, or separate `.css` files, unless the user says otherwise.
 
+## Serving assets: versioned + immutable
+
+Serve client modules through `versionedAssets` from `std/utils` so repeat visits
+load them from the browser cache instead of re-transpiling per request (measured:
+repeat visits 665ms → 157ms, zero asset requests). The shell stamps the entry
+module URL; publishing the val bumps the version, which invalidates instantly:
+
+```tsx
+import { versionedAssets } from "https://esm.town/v/std/utils/index.ts";
+const assets = versionedAssets();
+
+// In the HTML shell:
+<script src={assets.url("/frontend/index.tsx")} type="module" />
+
+// In the Hono app — current version → immutable cache, stale → 302 to current:
+app.get("/v*", (c) => assets.serve(c.req.raw));
+```
+
+See the `client-side-js` skill for how modules and their imports are served.
+
 ## View source link
 
 Every UI val should expose a way for users to see and remix its source. Both parts are required:


### PR DESCRIPTION
## What changed

Three skills now teach the versioned-immutable asset-caching pattern (`versionedAssets` from `std/utils`) as the default way to serve client modules:

| Skill | Change |
|---|---|
| `client-side-js` | New "Default: versioned, immutably cached modules" section after the per-request-transpilation explanation |
| `http-endpoints` | Canonical Hono example now stamps + serves versioned assets (plain `serveFile` kept as unstamped fallback) |
| `react-ui` | New "Serving assets: versioned + immutable" section with the shell + route snippet |

Plus a changeset (patch).

## Why

Per-request transpilation means every page load refetches every module. With version-stamped URLs + `Cache-Control: public, max-age=31536000, immutable`, repeat visits load all assets from the browser cache: measured 665ms → 157ms with zero asset requests. Invalidation is automatic — publishing bumps the val's version, the never-cached shell stamps the new prefix, and stale URLs 302 to the current version.

Prototype: https://www.val.town/x/casual_collab/asset-cache-proto

## Do not merge yet

Depends on the `versioned-assets` branch of the `std/utils` val merging first — until then `versionedAssets` is not exported from `https://esm.town/v/std/utils/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)