### PR TITLE
Add parseSkill and scoreSkill

### DIFF
--- a/.changeset/calm-nights-cheer.md
+++ b/.changeset/calm-nights-cheer.md
@@ -1,0 +1,5 @@
+---
+"@valtown/skills": minor
+---
+
+Add parseSkill and scoreSkill methods

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,17 @@
 {
   "name": "@valtown/skills",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@valtown/skills",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
+      },
       "devDependencies": {
         "@changesets/cli": "^2.31.0",
         "js-yaml": "^4.1.0",
@@ -1648,6 +1652,30 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
-    "js-yaml": "^4.1.0",
     "@changesets/cli": "^2.31.0",
     "typescript": "^7.0.0"
   },
@@ -33,5 +32,9 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "dependencies": {
+    "yaml": "^2.9.0",
+    "zod": "^4.4.3"
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -17,7 +17,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import yaml from "js-yaml";
+import { parse } from "yaml";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const SKILLS_DIR = join(ROOT, "plugin", "skills");
@@ -50,7 +50,7 @@ function parseSkill(dir) {
   const [, frontmatterRaw, body] = match;
   let fm;
   try {
-    fm = yaml.load(frontmatterRaw);
+    fm = parse(frontmatterRaw);
   } catch (err) {
     errors.push(`${dir}: invalid YAML frontmatter: ${err.message}`);
     return null;
@@ -62,7 +62,9 @@ function parseSkill(dir) {
     errors.push(`${dir}: "name" is required`);
   } else {
     if (!NAME_RE.test(name)) {
-      errors.push(`${dir}: name "${name}" must be lowercase letters, numbers, and hyphens`);
+      errors.push(
+        `${dir}: name "${name}" must be lowercase letters, numbers, and hyphens`,
+      );
     }
     if (name.length > MAX_NAME) {
       errors.push(`${dir}: name "${name}" exceeds ${MAX_NAME} characters`);
@@ -75,19 +77,29 @@ function parseSkill(dir) {
   if (typeof description !== "string" || description.length === 0) {
     errors.push(`${dir}: "description" is required`);
   } else if (description.length > MAX_DESCRIPTION) {
-    errors.push(`${dir}: description is ${description.length} chars (max ${MAX_DESCRIPTION})`);
+    errors.push(
+      `${dir}: description is ${description.length} chars (max ${MAX_DESCRIPTION})`,
+    );
   }
 
   let trig = [];
   if (triggers !== undefined) {
-    if (!Array.isArray(triggers) || triggers.some((t) => typeof t !== "string")) {
+    if (
+      !Array.isArray(triggers) ||
+      triggers.some((t) => typeof t !== "string")
+    ) {
       errors.push(`${dir}: "triggers" must be an array of strings`);
     } else {
       trig = triggers;
     }
   }
 
-  return { name: String(name), description: String(description), triggers: trig, body: body.trim() };
+  return {
+    name: String(name),
+    description: String(description),
+    triggers: trig,
+    body: body.trim(),
+  };
 }
 
 const dirs = readdirSync(SKILLS_DIR, { withFileTypes: true })
@@ -100,13 +112,16 @@ const seen = new Set();
 for (const dir of dirs) {
   const skill = parseSkill(dir);
   if (!skill) continue;
-  if (seen.has(skill.name)) errors.push(`${dir}: duplicate skill name "${skill.name}"`);
+  if (seen.has(skill.name))
+    errors.push(`${dir}: duplicate skill name "${skill.name}"`);
   seen.add(skill.name);
   skills.push(skill);
 }
 
 if (errors.length > 0) {
-  console.error(`\n✗ Skill validation failed:\n${errors.map((e) => `  - ${e}`).join("\n")}\n`);
+  console.error(
+    `\n✗ Skill validation failed:\n${errors.map((e) => `  - ${e}`).join("\n")}\n`,
+  );
   process.exit(1);
 }
 
@@ -118,7 +133,7 @@ const entries = skills
       `    description: ${JSON.stringify(s.description)},\n` +
       `    triggers: ${JSON.stringify(s.triggers)},\n` +
       `    body: ${JSON.stringify(s.body)},\n` +
-      `  },`
+      `  },`,
   )
   .join("\n");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export type { Skill, SkillSearchResult } from "./types.js";
 export { getSkills, searchSkills } from "./search.js";
 export { skills, skillList } from "./generated/skills.js";
+export { parseSkill } from "./parseSkill.js";
+export { scoreSkill } from "./scoreSkill.js";

--- a/src/parseSkill.ts
+++ b/src/parseSkill.ts
@@ -1,0 +1,65 @@
+import { parse } from "yaml";
+import { z } from "zod";
+import type { Skill } from "./types.js";
+
+/**
+ * Matches a leading `---`-delimited YAML frontmatter block and captures the
+ * frontmatter source (group 1) and the remaining markdown body (group 2).
+ * Input is normalized (BOM stripped, CRLF \u2192 LF) before matching, so this only
+ * has to deal with `\n`.
+ */
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+/**
+ * Validates a skill's frontmatter against the `@valtown/skills` `Skill` shape.
+ * `name` and `description` are required; `triggers` is optional and normalized
+ * to `string[]` (accepts a YAML list or a comma-separated string). Unknown keys
+ * are ignored so author additions don't fail validation.
+ */
+const SkillFrontmatterSchema = z.object({
+  name: z.string().trim().min(1),
+  description: z.string().trim().min(1),
+  triggers: z
+    .union([z.array(z.coerce.string()), z.coerce.string()])
+    .nullish()
+    .transform((value) => {
+      // `null` (a bare `triggers:` key) must be treated as absent, not coerced
+      // to the literal trigger "null".
+      if (value === undefined || value === null) return [] as string[];
+      const parts = Array.isArray(value) ? value : value.split(",");
+      return parts.map((part) => part.trim()).filter(Boolean);
+    }),
+});
+
+/**
+ * Parse a user-authored `SKILL.md` into a `Skill`. Returns `null` for any file
+ * that lacks frontmatter, has unparseable YAML, or fails validation — callers
+ * skip those rather than surfacing an error, so one malformed skill can't break
+ * a request. Validation is deliberately the same `Skill` shape official skills
+ * use, keeping user and official content one format.
+ */
+export function parseSkill(content: string): Skill | null {
+  // Strip a leading BOM and normalize CRLF so the regex only deals with `\n`.
+  const normalized = content.replace(/^\uFEFF/, "").replaceAll("\r\n", "\n");
+  const match = normalized.match(FRONTMATTER_RE);
+  if (!match) return null;
+
+  const [, frontmatterYaml, body] = match;
+
+  let data: unknown;
+  try {
+    data = parse(frontmatterYaml);
+  } catch {
+    return null;
+  }
+
+  const result = SkillFrontmatterSchema.safeParse(data);
+  if (!result.success) return null;
+
+  return {
+    name: result.data.name,
+    description: result.data.description,
+    triggers: result.data.triggers,
+    body: body.trim(),
+  };
+}

--- a/src/scoreSkill.ts
+++ b/src/scoreSkill.ts
@@ -1,0 +1,31 @@
+import type { Skill } from "./types.js";
+
+/**
+ * Case-insensitive token scorer mirroring `@valtown/skills`' `searchSkills`:
+ * name/description/triggers matches weigh more than body matches. Kept local so
+ * official and personal skills rank on a single comparable scale when merged in
+ * find_val_town_skills. A deliberately simple starting point — see
+ * docs/USER_SKILLS.md for the plan to upstream a shared scorer into the package.
+ */
+export function scoreSkill(skill: Skill, query: string): number {
+  const tokens = query
+    .toLowerCase()
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+  if (tokens.length === 0) return 0;
+
+  const name = skill.name.toLowerCase();
+  const description = skill.description.toLowerCase();
+  const triggers = skill.triggers.join(" ").toLowerCase();
+  const body = skill.body.toLowerCase();
+
+  let score = 0;
+  for (const token of tokens) {
+    if (name.includes(token)) score += 10;
+    if (description.includes(token)) score += 5;
+    if (triggers.includes(token)) score += 5;
+    if (body.includes(token)) score += 1;
+  }
+  return score;
+}

--- a/test/parseSkill.test.ts
+++ b/test/parseSkill.test.ts
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseSkill } from "../src/parseSkill.ts";
+
+test("parses valid frontmatter and trims the body", () => {
+  const skill = parseSkill(
+    `---
+name: weather-api
+description: Fetch current weather
+---
+
+Use the weather API like this.
+`,
+  );
+  assert.deepEqual(skill, {
+    name: "weather-api",
+    description: "Fetch current weather",
+    triggers: [],
+    body: "Use the weather API like this.",
+  });
+});
+
+test("parses content with a leading BOM and CRLF line endings", () => {
+  const skill = parseSkill(
+    "\uFEFF---\r\nname: a\r\ndescription: b\r\n---\r\nbody\r\n",
+  );
+  assert.deepEqual(skill, {
+    name: "a",
+    description: "b",
+    triggers: [],
+    body: "body",
+  });
+});
+
+test("normalizes a YAML list of triggers", () => {
+  const skill = parseSkill(
+    `---
+name: a
+description: b
+triggers:
+  - weather
+  - forecast
+---
+body`,
+  );
+  assert.deepEqual(skill?.triggers, ["weather", "forecast"]);
+});
+
+test("normalizes a comma-separated triggers string", () => {
+  const skill = parseSkill(
+    `---
+name: a
+description: b
+triggers: weather, forecast ,
+---
+body`,
+  );
+  assert.deepEqual(skill?.triggers, ["weather", "forecast"]);
+});
+
+test("treats a bare `triggers:` key (YAML null) as no triggers", () => {
+  const skill = parseSkill(
+    `---
+name: a
+description: b
+triggers:
+---
+body`,
+  );
+  assert.deepEqual(skill?.triggers, []);
+});
+
+test("ignores unknown frontmatter keys", () => {
+  const skill = parseSkill(
+    `---
+name: a
+description: b
+extra: ignored
+---
+body`,
+  );
+  assert.deepEqual(skill?.name, "a");
+});
+
+test("returns null when frontmatter is missing", () => {
+  assert.strictEqual(parseSkill("# Just markdown, no frontmatter"), null);
+});
+
+test("returns null when name is missing", () => {
+  assert.strictEqual(parseSkill("---\ndescription: b\n---\nbody"), null);
+});
+
+test("returns null when description is missing", () => {
+  assert.strictEqual(parseSkill("---\nname: a\n---\nbody"), null);
+});
+
+test("returns null for a blank name", () => {
+  assert.strictEqual(parseSkill("---\nname: '   '\ndescription: b\n---\nbody"), null);
+});
+
+test("returns null for unparseable YAML", () => {
+  assert.strictEqual(parseSkill("---\nname: : :\n  - bad\n---\nbody"), null);
+});


### PR DESCRIPTION
This moves parseSkill and scoreSkill into this package. It also adds zod, because it's necessary via parseSkill, and switches from js-yaml to yaml, making yaml a dependency instead of a devDependency like it was before. js-yaml is a somewhat troubled module and yaml is the better alternative.